### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,7 +20,7 @@ authors:
   given-names: "David E."
   orcid: "https://orcid.org/0000-0002-8308-5016"
 title: "QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization"
-version: 0.2.0
+version: "0.5.0"
 doi: 10.48550/arXiv.2307.02577
-date-released: 2023-05-08
+date-released: 2026-05-26
 url: "https://github.com/JuliaQUBO/QUBO.jl"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBO"
 uuid = "ce8c2e91-a970-4681-856b-16178c24a30c"
 authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"


### PR DESCRIPTION
## Summary

- Bump `Project.toml` from `0.4.0` to `0.5.0`.
- Update `CITATION.cff` to version `0.5.0` with release date `2026-05-26`.

## Release rationale

This prepares a minor release after the post-`v0.4.0` updates that modernized package compatibility to `QUBODrivers 0.4`, `QUBOTools 0.12`, `ToQUBO 0.3`, raised the Julia floor to `1.10`, added QUBOTools plotting regression coverage, and added the architecture documentation page.

## Tests run

- `git diff --check` - passed.
- `python - <<'PY' ... PY` metadata assertion for `Project.toml` and `CITATION.cff` - passed.
- `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'` - passed.
- `julia --project=docs docs/make.jl --skip-deploy` - passed.
- `julia --project=docs docs/multimake.jl --skip-deploy` - passed, with existing copied-QUBOTools `siteinfo.js` warnings.
- `julia --project=/tmp/qubo-v050-test-env -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.test("QUBO")'` - passed.

## Release notes

After this PR merges, register `v0.5.0` with Registrator. TagBot is already configured to create the GitHub release after registration.
