### PR TITLE
Fix release automation follow-ups

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,7 +12,7 @@ permissions:
   checks: read
   contents: write
   deployments: read
-  issues: read
+  issues: write
   discussions: read
   packages: read
   pages: read
@@ -28,6 +28,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
           ssh: ${{ secrets.SSH_KEY }}
-          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}

--- a/docs/multimake.jl
+++ b/docs/multimake.jl
@@ -78,7 +78,9 @@ function deploymultidocs(
         @info "Pushing updated documentation"
         push_deploy_branch(branch; remote)
 
-        run(`git checkout $main`)
+        if !restore_source_branch(main; remote)
+            @warn "Could not restore source branch after deployment" main
+        end
     else
         @info "No changes to aggregated documentation"
     end

--- a/docs/multimake_utils.jl
+++ b/docs/multimake_utils.jl
@@ -28,3 +28,14 @@ function push_deploy_branch(branch::AbstractString; remote::AbstractString = "or
 
     return nothing
 end
+
+function restore_source_branch(branch::AbstractString; remote::AbstractString = "origin")
+    if has_local_branch(branch) ||
+       success(`git fetch $remote $(branch_ref(branch)):$(branch_ref(branch))`)
+        run(`git checkout $branch`)
+
+        return true
+    end
+
+    return false
+end


### PR DESCRIPTION
Summary:

- Fix multidocs deployment cleanup on tag-triggered checkouts by fetching/restoring `main` when the local branch is absent.
- Allow TagBot to open a failure issue by granting `issues: write`.
- Remove stale placeholder comments from the TagBot workflow.
- Repository settings update already applied: replaced the `SSH_KEY` Actions secret and added a matching verified write-enabled deploy key for TagBot.

Tests run:

- `julia --project=docs -e 'using Pkg; Pkg.instantiate()'` passed.
- `julia --project=docs docs/multimake.jl --skip-deploy` passed.
- `julia --project=docs docs/make.jl --skip-deploy` passed.
- Local git simulation for `restore_source_branch("main")` from a detached tag-like checkout passed.

Notes:

- The v0.5.0 release itself is already registered and published.
- This PR prevents the two release follow-up failures from recurring: TagBot SSH authentication and tag-triggered multidocs cleanup.
