### PR TITLE
Modernize GitHub Actions runtime pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,15 @@ jobs:
             os: windows-latest
             arch: x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v6
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/doccleanup.yml
+++ b/.github/workflows/doccleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.10'
       - name: Install dependencies
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-docs
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.10'
       - name: Install dependencies

--- a/.github/workflows/validate-label-automation.yml
+++ b/.github/workflows/validate-label-automation.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Summary:

- Update local workflow uses of `actions/checkout` to a Node 24-capable release.
- Update `julia-actions/setup-julia` to v3 in CI and documentation workflows.
- Update `codecov/codecov-action` to v6 and migrate the deprecated `file` input to `files`.
- Update the pinned label-validation `actions/setup-python` SHA to v6.2.0.

Tests run:

- `python -m unittest discover -s .github/tests -p 'test_*.py'` passed.
- `python -c 'import pathlib, yaml; [yaml.safe_load(path.read_text()) for path in pathlib.Path(".github/workflows").glob("*.yml")]; print("workflow yaml ok")'` passed.
- `git diff --check` passed.
- `julia --project=docs docs/make.jl --skip-deploy` passed.
- `julia --project=docs docs/multimake.jl --skip-deploy` passed.

Notes:

- This follows up on the Node.js 20 deprecation warnings observed during the v0.5.0 release automation work.
