### PR TITLE
[codex] chore: ignore local caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ Manifest.toml
 
 # VS Code configuration
 .vscode/
+
+# Local tool and package caches
+.codex
+.julia-depot/


### PR DESCRIPTION
Adds local cache/tool paths to .gitignore so Julia depots and Codex local state do not flood git status.\n\nValidation: git check-ignore confirms .codex and .julia-depot/ are ignored.