### PR TITLE
Add QUBODrivers 0.5 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ ToQUBO = "9a412ddf-83fa-43b6-9748-7843c851aa65"
 [compat]
 JuMP             = "1"
 MathOptInterface = "1"
-QUBODrivers      = "0.4"
+QUBODrivers      = "0.4, 0.5"
 QUBOTools        = "0.12"
 ToQUBO           = "0.3"
 julia            = "1.10"

--- a/test/package_metadata.jl
+++ b/test/package_metadata.jl
@@ -8,7 +8,7 @@ function test_package_metadata()
 
         @test compat["julia"] == "1.10"
         @test compat["QUBOTools"] == "0.12"
-        @test compat["QUBODrivers"] == "0.4"
+        @test compat["QUBODrivers"] == "0.4, 0.5"
         @test compat["ToQUBO"] == "0.3"
 
         ci = read(joinpath(root, ".github", "workflows", "ci.yml"), String)


### PR DESCRIPTION
Summary
- Widened `QUBODrivers` compat from `0.4` to `0.4, 0.5`.
- Updated the package metadata test to assert the new compat bound.

Tests run
- `julia --startup-file=no -e 'using Pkg; Pkg.activate("/tmp/qubo-issue-28-env"; shared=false); Pkg.develop(path=pwd()); Pkg.add(Pkg.PackageSpec(name="QUBODrivers", version="0.5.0")); Pkg.resolve(); Pkg.status(); Pkg.test("QUBO"; coverage=false)'`
  - Result: passed. Resolver status included `QUBODrivers v0.5.0`; all QUBO tests passed.
- `julia --startup-file=no --project=/tmp/qubo-issue-28-env -e 'using Pkg; Pkg.add(["JuMP", "QUBOTools"]); Pkg.status()'`
  - Result: passed. Added direct docs-example dependencies to the temp validation environment.
- `julia --startup-file=no --project=/tmp/qubo-issue-28-env -e 'using JuMP, QUBO, QUBOTools; model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer)); @variable(model, x[1:3], Bin); @objective(model, Max, x[1] + 2 * x[2] + 3 * x[3]); @constraint(model, 0.3 * x[1] + 0.5 * x[2] + x[3] <= 1.6); optimize!(model); @assert objective_value(model) ≈ 5.0; n, l, q, α, β = QUBOTools.qubo(JuMP.unsafe_backend(model), :dense); @assert n >= 3; @assert count(!iszero, q) > 0; println("docs sampler smoke passed with objective=", objective_value(model), ", n=", n)'`
  - Result: passed with `docs sampler smoke passed with objective=5.0, n=8`.
- `git diff --check`
  - Result: passed.

Notes
- No separate lint, type-check, or formatting command is documented in this repository beyond the Julia test and docs workflows.

Closes #28
