### PR TITLE
Prepare v0.5.1 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,7 +20,7 @@ authors:
   given-names: "David E."
   orcid: "https://orcid.org/0000-0002-8308-5016"
 title: "QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization"
-version: "0.5.0"
+version: "0.5.1"
 doi: 10.48550/arXiv.2307.02577
-date-released: 2026-05-26
+date-released: 2026-06-03
 url: "https://github.com/JuliaQUBO/QUBO.jl"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBO"
 uuid = "ce8c2e91-a970-4681-856b-16178c24a30c"
 authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"


### PR DESCRIPTION

## Summary

- Bump `Project.toml` from `0.5.0` to `0.5.1`.
- Update `CITATION.cff` to version `0.5.1` with release date `2026-06-03`.

## Release rationale

This prepares a patch release for the post-`v0.5.0` maintenance updates on `main`, especially the `QUBODrivers = "0.4, 0.5"` compat widening so registry users can resolve QUBO.jl with QUBODrivers 0.5.

## Tests run

- `git diff --check` - passed.
- Release metadata assertion for `Project.toml` and `CITATION.cff` - passed.
- Docs dependency setup with `Pkg.develop` and `Pkg.instantiate` - passed.
- `docs/make.jl --skip-deploy` - passed.
- `docs/multimake.jl --skip-deploy` - passed, with existing QUBOTools `siteinfo.js` warnings.
- Package test in `/tmp/qubo-v051-test-env` - passed.
- Fresh-depot package test in `/tmp/qubo-v051-clean-depot` - passed. Note: the local checkout has ignored manifests/development state, so sibling QUBO ecosystem packages resolved to local paths during that run.

## Release notes

After this PR merges, register `v0.5.1` with Registrator. TagBot is configured to create the GitHub release after registration.
