### PR TITLE
Add ecosystem resolution canary CI

### DIFF
--- a/.github/workflows/ecosystem-canary.yml
+++ b/.github/workflows/ecosystem-canary.yml
@@ -1,0 +1,59 @@
+name: Ecosystem Canary
+
+on:
+  schedule:
+    - cron: "17 8 * * 1"
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/workflows/ecosystem-canary.yml"
+      - "scripts/compat_matrix.jl"
+      - "scripts/ecosystem_canary.jl"
+      - "Project.toml"
+      - "Manifest.toml"
+      - "docs/Project.toml"
+      - "docs/Manifest.toml"
+
+jobs:
+  tier-1:
+    name: Tier 1 resolution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.11"
+      - uses: julia-actions/cache@v3
+      - name: Print compat matrix
+        run: >
+          julia scripts/compat_matrix.jl
+          QUBO QUBOLib MQLib IsingSolvers TenSolver QuantumAnnealingInterface
+      - name: Resolve and import pure-Julia tier
+        run: >
+          julia scripts/ecosystem_canary.jl --tier tier-1
+          QUBO QUBOLib MQLib IsingSolvers TenSolver QuantumAnnealingInterface
+
+  tier-2:
+    name: Tier 2 resolution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.11"
+      - uses: julia-actions/cache@v3
+      - name: Print compat matrix
+        run: >
+          julia scripts/compat_matrix.jl
+          QUBO QUBOLib MQLib IsingSolvers TenSolver QuantumAnnealingInterface
+          DWave PySA CIMOptimizer QiskitOpt
+      - name: Resolve and import Python-backed tier
+        run: >
+          julia scripts/ecosystem_canary.jl --tier tier-2
+          --allow-import-failure DWave
+          --allow-import-failure PySA
+          --allow-import-failure CIMOptimizer
+          --allow-import-failure QiskitOpt
+          QUBO QUBOLib MQLib IsingSolvers TenSolver QuantumAnnealingInterface
+          DWave PySA CIMOptimizer QiskitOpt

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Code Coverage](https://codecov.io/gh/JuliaQUBO/QUBO.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaQUBO/QUBO.jl)
 [![CI](https://github.com/JuliaQUBO/QUBO.jl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JuliaQUBO/QUBO.jl/actions/workflows/ci.yml)
+[![Ecosystem Canary](https://github.com/JuliaQUBO/QUBO.jl/actions/workflows/ecosystem-canary.yml/badge.svg?branch=main)](https://github.com/JuliaQUBO/QUBO.jl/actions/workflows/ecosystem-canary.yml)
 [![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaqubo.github.io/QUBO.jl/dev/)
 [![Zenodo/DOI](https://zenodo.org/badge/614041491.svg)](https://zenodo.org/badge/latestdoi/614041491)
 [![JuliaCon 2022](https://img.shields.io/badge/JuliaCon-2022-9558b2)](https://www.youtube.com/watch?v=OTmzlTbqdNo)
@@ -19,6 +20,12 @@
 
 [QUBO.jl](https://github.com/JuliaQUBO/QUBO.jl) is an all-in-one package for working with QUBO models in [JuMP](https://github.com/jump-dev/JuMP.jl) and interfacing with their solvers.
 This project aggregates and extends functionality from its complementary packages [ToQUBO.jl](https://github.com/JuliaQUBO/ToQUBO.jl), [QUBODrivers.jl](https://github.com/JuliaQUBO/QUBODrivers.jl) and [QUBOTools.jl](https://github.com/JuliaQUBO/QUBOTools.jl).
+
+The ecosystem canary composes the latest registered QUBO packages in fresh Julia
+environments to catch compatibility drift across package boundaries. A red
+canary means at least one tier no longer resolves or imports together; inspect
+the workflow log's compatibility matrix first, then update the offending
+package bounds or release the missing compatibility work.
 
 ## QUBO? 🟦
 

--- a/scripts/compat_matrix.jl
+++ b/scripts/compat_matrix.jl
@@ -1,0 +1,97 @@
+#!/usr/bin/env julia
+
+using Pkg
+
+const JULIA_UUID = Base.UUID("1222c4b2-2114-5bfd-aeef-88e4692bbb3e")
+const WATCHED_DEPS = ["julia", "QUBODrivers", "QUBOTools", "ToQUBO"]
+
+function ensure_general_registry()
+    registries = Pkg.Registry.reachable_registries()
+    if isempty(registries)
+        Pkg.Registry.add("General")
+        registries = Pkg.Registry.reachable_registries()
+    else
+        Pkg.Registry.update()
+        registries = Pkg.Registry.reachable_registries()
+    end
+    matches = filter(registry -> registry.name == "General", registries)
+    isempty(matches) && error("General registry is not available")
+    return only(matches)
+end
+
+function package_maps(registry)
+    uuid_by_name = Dict{String,Base.UUID}()
+    name_by_uuid = Dict{Base.UUID,String}()
+    for (uuid, entry) in registry.pkgs
+        uuid_by_name[entry.name] = uuid
+        name_by_uuid[uuid] = entry.name
+    end
+    name_by_uuid[JULIA_UUID] = "julia"
+    return uuid_by_name, name_by_uuid
+end
+
+function latest_compat(registry, uuid::Base.UUID)
+    info = Pkg.Registry.registry_info(registry.pkgs[uuid])
+    latest = maximum(keys(info.version_info))
+    compat_by_version = Pkg.Registry.compat_info(info)
+    compat = get(compat_by_version, latest, Dict{Base.UUID,Pkg.Types.VersionSpec}())
+    return latest, compat
+end
+
+function compat_string(compat, dep_uuid)
+    spec = get(compat, dep_uuid, nothing)
+    spec === nothing && return "-"
+    return string(spec)
+end
+
+function print_matrix(packages)
+    registry = ensure_general_registry()
+    uuid_by_name, _ = package_maps(registry)
+    watched = Pair{String,Base.UUID}[]
+    for dep in WATCHED_DEPS
+        if dep == "julia"
+            push!(watched, dep => JULIA_UUID)
+        elseif haskey(uuid_by_name, dep)
+            push!(watched, dep => uuid_by_name[dep])
+        end
+    end
+
+    println("Registered ecosystem compatibility matrix")
+    println("Registry: $(registry.name)")
+    println()
+
+    header = ["Package", "Latest", WATCHED_DEPS...]
+    rows = Vector{Vector{String}}()
+    for package in packages
+        if !haskey(uuid_by_name, package)
+            push!(rows, [package, "not registered", fill("-", length(WATCHED_DEPS))...])
+            continue
+        end
+        latest, compat = latest_compat(registry, uuid_by_name[package])
+        values = [compat_string(compat, dep_uuid) for (_, dep_uuid) in watched]
+        push!(rows, [package, string(latest), values...])
+    end
+
+    widths = [max(length(header[i]), maximum(length(row[i]) for row in rows)) for i in eachindex(header)]
+
+    function print_row(row)
+        for (i, cell) in pairs(row)
+            i > 1 && print("  ")
+            print(rpad(cell, widths[i]))
+        end
+        println()
+    end
+
+    print_row(header)
+    print_row([repeat("-", width) for width in widths])
+    foreach(print_row, rows)
+end
+
+function main(args)
+    packages = isempty(args) ? ["QUBO"] : args
+    print_matrix(packages)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main(ARGS)
+end

--- a/scripts/ecosystem_canary.jl
+++ b/scripts/ecosystem_canary.jl
@@ -1,0 +1,107 @@
+#!/usr/bin/env julia
+
+using Pkg
+
+function parse_args(args)
+    tier = "custom"
+    allow_import_failure = Set{String}()
+    packages = String[]
+    index = 1
+    while index <= length(args)
+        arg = args[index]
+        if arg == "--tier"
+            index == length(args) && error("--tier requires a value")
+            tier = args[index + 1]
+            index += 2
+        elseif arg == "--allow-import-failure"
+            index == length(args) && error("--allow-import-failure requires a package name")
+            push!(allow_import_failure, args[index + 1])
+            index += 2
+        elseif startswith(arg, "--")
+            error("unknown option: $arg")
+        else
+            push!(packages, arg)
+            index += 1
+        end
+    end
+    isempty(packages) && error("at least one package is required")
+    return tier, allow_import_failure, packages
+end
+
+function ensure_general_registry()
+    registries = Pkg.Registry.reachable_registries()
+    if isempty(registries)
+        Pkg.Registry.add("General")
+    else
+        Pkg.Registry.update()
+    end
+end
+
+function print_compat_matrix(packages)
+    script = joinpath(@__DIR__, "compat_matrix.jl")
+    isfile(script) || return
+    try
+        run(`$(Base.julia_cmd()) $script $(packages)`)
+    catch err
+        @warn "compat matrix failed" exception = (err, catch_backtrace())
+    end
+end
+
+function resolve_packages(tier, packages)
+    println("Ecosystem canary tier: $tier")
+    println("Packages: $(join(packages, ", "))")
+    Pkg.activate(; temp = true)
+    ensure_general_registry()
+    try
+        Pkg.add(packages)
+        Pkg.resolve()
+        Pkg.status()
+    catch err
+        println()
+        println("Julia package resolution failed for $tier.")
+        println("Compatibility matrix for this tier:")
+        print_compat_matrix(packages)
+        println()
+        showerror(stdout, err, catch_backtrace())
+        println()
+        exit(1)
+    end
+end
+
+function import_package(name)
+    if !occursin(r"^[A-Za-z_][A-Za-z0-9_]*$", name)
+        error("invalid package name: $name")
+    end
+    Base.eval(Main, Meta.parse("using $name"))
+end
+
+function smoke_import(packages, allow_import_failure)
+    failed = false
+    for package in packages
+        print("Importing $package ... ")
+        try
+            import_package(package)
+            println("ok")
+        catch err
+            println("failed")
+            if package in allow_import_failure
+                @warn "optional import failed after successful resolution" package exception = (err, catch_backtrace())
+            else
+                showerror(stdout, err, catch_backtrace())
+                println()
+                failed = true
+            end
+        end
+    end
+    failed && exit(1)
+end
+
+function main(args)
+    tier, allow_import_failure, packages = parse_args(args)
+    resolve_packages(tier, packages)
+    smoke_import(packages, allow_import_failure)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main(ARGS)
+end


### PR DESCRIPTION
## Summary

- Add an ecosystem canary workflow that resolves the latest registered QUBO package tiers in fresh Julia environments.
- Add a canary runner that fails on Julia resolver conflicts and tolerates only tier-2 Python-backed import failures after successful resolution.
- Add a registry compatibility matrix helper so failures identify the package bounds causing drift.
- Document the canary badge and what a red canary means in the README.

## Canary Status

Expected red on day one.

Local tier-1 canary run failed at Julia package resolution, as intended. The resolver reports an unsatisfiable `QUBODrivers` requirement: `QuantumAnnealingInterface` restricts `QUBODrivers` to `0.5`, `TenSolver` restricts it to `0.3`, and the current registered QUBO stack requires the newer release-wave compatibility path.

Local tier-2 canary run also failed at Julia package resolution, as intended. The compatibility matrix additionally shows current lower bounds for `DWave`, `PySA`, and `CIMOptimizer`.

The canary should turn green without changing canary logic as the WS2 driver compatibility release wave lands.

## Branch Hygiene

- Base branch: `main`
- Created/rebased from: `origin/main`
- Stacked on experimental branch: no
- Prerequisite parked branches: none for this canary PR; downstream driver compatibility PRs are what should turn the canary green later.

## Validation

- `julia --project=. scripts/compat_matrix.jl QUBO QUBOLib MQLib IsingSolvers TenSolver QuantumAnnealingInterface`: passed
- `julia --project=. scripts/ecosystem_canary.jl --tier smoke Pkg`: passed
- `julia --project=. scripts/ecosystem_canary.jl --tier tier-1 QUBO QUBOLib MQLib IsingSolvers TenSolver QuantumAnnealingInterface`: expected failure, resolver conflict in `QUBODrivers`
- `julia --project=. scripts/ecosystem_canary.jl --tier tier-2 --allow-import-failure DWave --allow-import-failure PySA --allow-import-failure CIMOptimizer --allow-import-failure QiskitOpt QUBO QUBOLib MQLib IsingSolvers TenSolver QuantumAnnealingInterface DWave PySA CIMOptimizer QiskitOpt`: expected failure, resolver conflict in `QUBODrivers`
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: passed
- `python3 -m unittest discover -s .github/tests`: passed
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ecosystem-canary.yml")); print("yaml ok")'`: passed
- `git diff --check`: passed

Closes #42
